### PR TITLE
add predicate filter option

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ between retries can be specified via the `options` parameter:
 * `max_interval` if specified, maximum amount that interval can increase to
 * `timeout` total time to wait for the operation to succeed in milliseconds
 * `max_tries` maximum number of attempts to try the operation
+* `predicate` to be used as bluebird's [Filtered Catch](http://bluebirdjs.com/docs/api/catch.html#filtered-catch). `func` will be retried only if the predicate expectation is met, it will otherwise fail immediately.
 
 Note that `timeout` does not actually set a real timeout for the operation,
 but actually computes a maximum number of attempts based on the interval

--- a/lib/bluebird-retry.js
+++ b/lib/bluebird-retry.js
@@ -52,21 +52,30 @@ function retry(func, options) {
     var tries = 0;
     var start = new Date().getTime();
 
+    // If the user didn't supply a predicate function then add one that
+    // always succeeds.
+    //
+    // This is used in bluebird's filtered catch to flag the error types
+    // that should retry.
+    var predicate = options.predicate || function(err) { return true; }
+    var stopped = false;
+
     function try_once() {
         var tryStart = new Date().getTime();
         return Promise.attempt(function() {
                 return func();
             })
-            .caught(function(err) {
-                if (err instanceof StopError) {
-                    if (err.err instanceof Error) {
-                        return Promise.reject(err.err);
-                    } else {
-                        return Promise.reject(err);
-                    }
+            .caught(StopError, function(err) {
+                stopped = true;
+                if (err.err instanceof Error) {
+                    return Promise.reject(err.err);
+                } else {
+                    return Promise.reject(err);
                 }
-                if (options.predicate && !(err instanceof options.predicate)) {
-                    return Promise.reject(err)
+            })
+            .caught(predicate, function(err) {
+                if (stopped) {
+                    return Promise.reject(err);
                 }
                 ++tries;
                 if (tries > 1) {

--- a/lib/bluebird-retry.js
+++ b/lib/bluebird-retry.js
@@ -65,6 +65,9 @@ function retry(func, options) {
                         return Promise.reject(err);
                     }
                 }
+                if (options.predicate && !(err instanceof options.predicate)) {
+                    return Promise.reject(err)
+                }
                 ++tries;
                 if (tries > 1) {
                     interval = backoff(interval, options);

--- a/test/bluebird-retry.spec.js
+++ b/test/bluebird-retry.spec.js
@@ -214,57 +214,60 @@ describe('bluebird-retry', function() {
                 }));
             });
 
+            var predicates = {
+                'error class': RangeError,
+                'predicate function': function(err) { return err instanceof RangeError; }
+            };
 
-            it('retries only for a certain error', function(done) {
-                var countSuccess = countCalls(funcs.successAfter(5, RangeError));
-                return retry(countSuccess, {
-                    interval: 10, 
-                    max_tries: 10,
-                    predicate: RangeError
-                })
-                    .then(function() {
-                        expect(countSuccess.count).equal(5);
+            _.each(predicates, function(predicate, what) {
+                it('retries only when matching ' + what, function(done) {
+                    var countSuccess = countCalls(funcs.successAfter(5, RangeError));
+                    return retry(countSuccess, {
+                        interval: 10,
+                        max_tries: 10,
+                        predicate: predicate
                     })
-                    .done(done, done);
+                        .then(function() {
+                            expect(countSuccess.count).equal(5);
+                        })
+                        .done(done, done);
+                });
+
+                it('fails immediately with non matching ' + what, function(done) {
+                    var countSuccess = countCalls(funcs.failure);
+                    return retry(countSuccess, {
+                        interval: 10,
+                        max_tries: 10,
+                        predicate: predicate
+                    })
+                        .then(function() {
+                            throw new Error('unexpected success');
+                        })
+                        .caught(function(err) {
+                            expect(err.message).match(/not yet/);
+                            expect(countSuccess.count).equal(1);
+                        })
+                        .done(done, done);
+                });
+
+                it('fails after a few tries when matching ' + what, function(done) {
+                    var countSuccess = countCalls(funcs.successAfter(100, RangeError));
+                    return retry(countSuccess, {
+                        interval: 10,
+                        max_tries: 10,
+                        predicate: predicate
+                    })
+                        .then(function() {
+                            throw new Error('unexpected success');
+                        })
+                        .caught(function(err) {
+                            expect(err.message).match(/operation timed out/);
+                            expect(err.failure.message).match(/catch this/);
+                            expect(countSuccess.count).equal(10);
+                        })
+                        .done(done, done);
+                });
             });
-
-            it('fails immediately while expecting only a certain error', function(done) {
-                var countSuccess = countCalls(funcs.failure);
-                return retry(countSuccess, {
-                    interval: 10, 
-                    max_tries: 10,
-                    predicate: RangeError
-                })
-                    .then(function() {
-                        throw new Error('unexpected success');
-                    })
-                    .caught(function(err) {
-                        expect(err.message).match(/not yet/);
-                        expect(countSuccess.count).equal(1);
-                    })
-                    .done(done, done);
-            });
-
-
-            it('fails after a few tries expecting only a certain error', function(done) {
-                var countSuccess = countCalls(funcs.successAfter(100, RangeError));
-                return retry(countSuccess, {
-                    interval: 10, 
-                    max_tries: 10,
-                    predicate: RangeError
-                })
-                    .then(function() {
-                        throw new Error('unexpected success');
-                    })
-                    .caught(function(err) {
-                        expect(err.message).match(/operation timed out/);
-                        expect(err.failure.message).match(/catch this/);
-                        expect(countSuccess.count).equal(10);
-                    })
-                    .done(done, done);
-            });
-
-
         });
     });
 });


### PR DESCRIPTION
Make it possible to retry only upon errors that are eligible by the predicate option.

Adapted from the original proposal by @gastonelhordoy in #27 
