### PR TITLE
handle the case where the function rejects with a non-error

### DIFF
--- a/lib/bluebird-retry.js
+++ b/lib/bluebird-retry.js
@@ -73,6 +73,13 @@ function retry(func, options) {
 
                 if ((max_tries && (tries === max_tries) ||
                     (giveup_time && (now + interval >= giveup_time)))) {
+
+                    if (! (err instanceof Error)) {
+                        var failure = err;
+                        err = new Error('rejected with non-error: ' + failure);
+                        err.failure = failure;
+                    }
+
                     var timeout = new Error('operation timed out after ' + (now - start) + ' ms, ' + tries + ' tries' + ' failure: ' + err.message);
                     timeout.failure = err;
                     timeout.code = 'ETIMEDOUT';

--- a/test/bluebird-retry.spec.js
+++ b/test/bluebird-retry.spec.js
@@ -107,6 +107,26 @@ describe('bluebird-retry', function() {
                     .done(done, done);
             });
 
+            it('handles rejection with a non-error', function(done) {
+                function badfail() {
+                    return Promise.reject('something bad happened')
+                }
+                return retry(badfail, {interval: 10, max_tries: 2})
+                    .then(function() {
+                        throw new Error('unexpected success');
+                    })
+                    .caught(function(err) {
+                        console.log(err.stack)
+                        expect(err).match(/operation timed out.*something bad happened/);
+                        expect(err.message).match(/something bad happened/);
+                        expect(err.message).match(/operation timed out/);
+                        expect(err.stack).match(/something bad happened/);
+                        expect(err.failure.failure).equals('something bad happened');
+                    })
+                    .done(done, done);
+            });
+
+
             it('calculates max_tries based on timeout', function(done) {
                 var countSuccess = countCalls(funcs.successAfter(500));
                 return retry(countSuccess, {interval: 50, timeout: 475})


### PR DESCRIPTION
If the rejection isn't an instance of Error, wrap it in an Error
class before constructing the timeout Error so the overall rejection
isn't undefined.

Fixes #26 