### PR TITLE
remove browserified product (keep it for tests though)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 coverage
+browser/bluebird-retry.js

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "scripts": {
     "test": "gulp test"
   },
-  "browser": "./browser/bluebird-retry.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/demmer/bluebird-retry.git"


### PR DESCRIPTION
This should fix #35 (haven't tested it myself)
it may break some user's assumptions though, if they expect to get an already browserified module. 

I'd expect this module to work well as cjs universal javascript without any special packaging, and let the end-user decide how to handle it (AFAIK all bundlers support this approach).